### PR TITLE
Allow overlapping tap sounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ LizardButton is a minimal [.NET MAUI](https://learn.microsoft.com/dotnet/maui/wh
 - Audio handled through [`Plugin.Maui.Audio`](https://github.com/jfversluis/Plugin.Maui.Audio).
 - Sound effect packaged as a MAUI asset for consistent playback.
 - Image and sound assets stored under `Resources/Images` and `Resources/Sounds`.
+- Rapid consecutive taps play overlapping sound effects without cutting off previous sounds.
 
 ## Getting started
 


### PR DESCRIPTION
## Summary
- Play audio from memory for each tap so rapid taps overlap without cutting off prior sounds
- Document overlapping audio playback capability

## Testing
- `dotnet build` *(fails: NETSDK1147, missing workloads even after `dotnet workload restore`)*
- `dotnet workload restore`


------
https://chatgpt.com/codex/tasks/task_e_6893765f851c83328cb927a912e8f7ab