### PR TITLE
Fix stack overflow when stopping audio playback

### DIFF
--- a/ViewModels/MainPageViewModel.cs
+++ b/ViewModels/MainPageViewModel.cs
@@ -59,11 +59,15 @@ public partial class MainPageViewModel : BaseViewModel
                 MemoryStream stream = new(audioData);
                 IAudioPlayer player = audioManager.CreatePlayer(stream);
                 activePlayers.Add(player);
-                player.PlaybackEnded += (s, e) =>
+
+                void OnPlaybackEnded(object? s, EventArgs e)
                 {
+                    player.PlaybackEnded -= OnPlaybackEnded;
                     player.Dispose();
                     activePlayers.Remove(player);
-                };
+                }
+
+                player.PlaybackEnded += OnPlaybackEnded;
                 player.Play();
             }
 


### PR DESCRIPTION
## Summary
- Unsubscribe from audio playback event before disposing player to avoid recursive calls

## Testing
- `dotnet build` *(fails: NETSDK1147 workloads must be installed: wasi-experimental)*

------
https://chatgpt.com/codex/tasks/task_e_68938ab250bc8332b73fbe29c6559f0e