### PR TITLE
Add localized persistent tap counter

### DIFF
--- a/MainPage.xaml
+++ b/MainPage.xaml
@@ -3,13 +3,23 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:viewModel="clr-namespace:LizardButton.ViewModels"
-             x:DataType="viewModel:BaseViewModel">
+             x:DataType="viewModel:MainPageViewModel">
     <Grid x:Name="RootGrid">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <Label Grid.Row="0"
+               Text="{Binding CountText}"
+               HorizontalOptions="Center"
+               VerticalOptions="Center"
+               Margin="0,20,0,10"
+               FontSize="18" />
         <AbsoluteLayout x:Name="AnimationArea"
-                        Grid.Row="0"
-                        Grid.Column="0"
+                        Grid.Row="1"
                         BackgroundColor="Transparent" />
-        <Border HeightRequest="140"
+        <Border Grid.Row="1"
+                HeightRequest="140"
                 WidthRequest="140"
                 HorizontalOptions="Center"
                 VerticalOptions="Center"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ LizardButton is a minimal [.NET MAUI](https://learn.microsoft.com/dotnet/maui/wh
 - Sound effect packaged as a MAUI asset for consistent playback.
 - Image and sound assets stored under `Resources/Images` and `Resources/Sounds`.
 - Rapid consecutive taps play overlapping sound effects without cutting off previous sounds.
+- Persistent tap counter stored in cross-platform preferences with a localized label.
 
 ## Getting started
 


### PR DESCRIPTION
## Summary
- show tap count at top of main page
- persist count across sessions using Preferences
- localize counter label for English and French

## Testing
- `dotnet build` *(fails: NETSDK1147 To build this project, the following workloads must be installed: wasi-experimental)*

------
https://chatgpt.com/codex/tasks/task_e_68938f51426c8332ba1697ee138cc535