### PR TITLE
Add theme-aware styles for light and dark mode

### DIFF
--- a/MainPage.xaml
+++ b/MainPage.xaml
@@ -23,19 +23,14 @@
                 WidthRequest="140"
                 HorizontalOptions="Center"
                 VerticalOptions="Center"
-                Stroke="#4B0082"
-                StrokeThickness="4">
+                Stroke="{AppThemeBinding Light={StaticResource PrimaryBrush}, Dark={StaticResource PrimaryDarkBrush}}"
+                StrokeThickness="4"
+                Background="{AppThemeBinding Light={StaticResource MainButtonGradientLight}, Dark={StaticResource MainButtonGradientDark}}">
             <Border.StrokeShape>
                 <RoundRectangle CornerRadius="70" />
             </Border.StrokeShape>
-            <Border.Background>
-                <LinearGradientBrush StartPoint="0,0" EndPoint="0,1">
-                    <GradientStop Color="#BB86FC" Offset="0" />
-                    <GradientStop Color="#3700B3" Offset="1" />
-                </LinearGradientBrush>
-            </Border.Background>
             <Border.Shadow>
-                <Shadow Brush="Black"
+                <Shadow Brush="{AppThemeBinding Light={StaticResource BlackBrush}, Dark={StaticResource WhiteBrush}}"
                         Opacity="0.5"
                         Radius="15"
                         Offset="0,10" />
@@ -65,3 +60,4 @@
         </Border>
     </Grid>
 </ContentPage>
+

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ LizardButton is a minimal [.NET MAUI](https://learn.microsoft.com/dotnet/maui/wh
 - Single page user interface without a shell or navigation framework.
 - MVVM architecture with a `MainPageViewModel` that triggers audio playback and image animation.
 - Visual 3D lizard button styled with gradient, border, and shadow.
+- Automatic light and dark mode styling that adapts to the system theme.
 - Audio handled through [`Plugin.Maui.Audio`](https://github.com/jfversluis/Plugin.Maui.Audio).
 - Sound effect packaged as a MAUI asset for consistent playback.
 - Image and sound assets stored under `Resources/Images` and `Resources/Sounds`.

--- a/Resources/Styles/Colors.xaml
+++ b/Resources/Styles/Colors.xaml
@@ -29,6 +29,7 @@
     <Color x:Key="Gray950">#141414</Color>
 
     <SolidColorBrush x:Key="PrimaryBrush" Color="{StaticResource Primary}"/>
+    <SolidColorBrush x:Key="PrimaryDarkBrush" Color="{StaticResource PrimaryDark}"/>
     <SolidColorBrush x:Key="SecondaryBrush" Color="{StaticResource Secondary}"/>
     <SolidColorBrush x:Key="TertiaryBrush" Color="{StaticResource Tertiary}"/>
     <SolidColorBrush x:Key="WhiteBrush" Color="{StaticResource White}"/>
@@ -42,4 +43,13 @@
     <SolidColorBrush x:Key="Gray600Brush" Color="{StaticResource Gray600}"/>
     <SolidColorBrush x:Key="Gray900Brush" Color="{StaticResource Gray900}"/>
     <SolidColorBrush x:Key="Gray950Brush" Color="{StaticResource Gray950}"/>
+
+    <LinearGradientBrush x:Key="MainButtonGradientLight" StartPoint="0,0" EndPoint="0,1">
+        <GradientStop Color="{StaticResource Primary}" Offset="0" />
+        <GradientStop Color="{StaticResource Tertiary}" Offset="1" />
+    </LinearGradientBrush>
+    <LinearGradientBrush x:Key="MainButtonGradientDark" StartPoint="0,0" EndPoint="0,1">
+        <GradientStop Color="{StaticResource PrimaryDark}" Offset="0" />
+        <GradientStop Color="{StaticResource Primary}" Offset="1" />
+    </LinearGradientBrush>
 </ResourceDictionary>


### PR DESCRIPTION
## Summary
- enable light and dark theme switching by adding theme-aware brushes and gradient resources
- bind the main button's stroke, background and shadow to the current theme
- document automatic light/dark support in README

## Testing
- `dotnet build` *(fails: NETSDK1147: To build this project, the following workloads must be installed: wasi-experimental)*


------
https://chatgpt.com/codex/tasks/task_e_6893922efbbc8332849c4d359da79400