### PR TITLE
Validate animation area dimensions in ShowAnimatedImage

### DIFF
--- a/MainPage.xaml.cs
+++ b/MainPage.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using LizardButton.ViewModels;
+using Microsoft.Maui.Devices;
 
 namespace LizardButton;
 
@@ -26,9 +27,21 @@ public partial class MainPage : ContentPage
         try
         {
             Random random = new();
+            double imageSize = 64.0;
             double areaWidth = AnimationArea.Width;
             double areaHeight = AnimationArea.Height;
-            double imageSize = 64.0;
+
+            if (double.IsNaN(areaWidth) || double.IsNaN(areaHeight) || areaWidth <= imageSize || areaHeight <= imageSize)
+            {
+                var displayInfo = DeviceDisplay.MainDisplayInfo;
+                areaWidth = displayInfo.Width / displayInfo.Density;
+                areaHeight = displayInfo.Height / displayInfo.Density;
+            }
+
+            if (double.IsNaN(areaWidth) || double.IsNaN(areaHeight) || areaWidth <= imageSize || areaHeight <= imageSize)
+            {
+                return;
+            }
 
             // Position random
             double startX = random.NextDouble() * (areaWidth - imageSize);


### PR DESCRIPTION
## Summary
- ensure animation area is large enough for image
- fallback to full screen size when layout dimensions are invalid

## Testing
- `dotnet build` *(fails: NETSDK1147 missing workload wasi-experimental)*

------
https://chatgpt.com/codex/tasks/task_e_6893b0f951248332826211e97c63dfa8