### PR TITLE
Use shared random instance on UI thread

### DIFF
--- a/MainPage.xaml.cs
+++ b/MainPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using LizardButton.ViewModels;
+using LizardButton.ViewModels;
+using Microsoft.Maui.ApplicationModel;
 
 namespace LizardButton;
 
@@ -23,9 +24,16 @@ public partial class MainPage : ContentPage
     /// <returns>Une tâche asynchrone.</returns>
     public async Task ShowAnimatedImage()
     {
+        if (!MainThread.IsMainThread)
+        {
+            // Ensure the animation runs on the UI thread for thread safety.
+            await MainThread.InvokeOnMainThreadAsync(ShowAnimatedImage);
+            return;
+        }
+
         try
         {
-            Random random = new();
+            Random random = Random.Shared;
             double areaWidth = AnimationArea.Width;
             double areaHeight = AnimationArea.Height;
             double imageSize = 64.0;


### PR DESCRIPTION
## Summary
- replace `new Random()` with `Random.Shared`
- run animation method on UI thread for thread safety

## Testing
- `dotnet workload restore`
- `dotnet build` *(fails: NETSDK1147 requires wasi-experimental workload)*

------
https://chatgpt.com/codex/tasks/task_e_6893b10bc9e08332b8f46f6d2ca4c063