### PR TITLE
Show fractional tap counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ LizardButton is a minimal [.NET MAUI](https://learn.microsoft.com/dotnet/maui/wh
 - Sound effect packaged as a MAUI asset for consistent playback.
 - Image and sound assets stored under `Resources/Images` and `Resources/Sounds`.
 - Rapid consecutive taps play overlapping sound effects without cutting off previous sounds.
-- Persistent, unlimited tap counter stored in cross-platform preferences with localized unit formatting (e.g., 1K, 1M).
+- Persistent, unlimited tap counter stored in cross-platform preferences with localized unit formatting (e.g., 1.23K, 1.23M).
 - Custom lizard splash screen and app icon.
 
 ## Getting started

--- a/ViewModels/MainPageViewModel.cs
+++ b/ViewModels/MainPageViewModel.cs
@@ -134,23 +134,25 @@ public partial class MainPageViewModel : BaseViewModel, IDisposable
         BigInteger thousand = new(1000);
         int unitIndex = 0;
         BigInteger value = number;
-        BigInteger remainder = BigInteger.Zero;
 
         while (value >= thousand && unitIndex < units.Length - 1)
         {
-            remainder = value % thousand;
             value /= thousand;
             unitIndex++;
         }
 
         string result = value.ToString(CultureInfo.CurrentUICulture);
 
-        if (unitIndex > 0 && remainder != 0)
+        if (unitIndex > 0)
         {
-            int firstDigit = (int)(remainder / (thousand / 10));
-            if (firstDigit > 0)
+            BigInteger scale = BigInteger.Pow(thousand, unitIndex);
+            BigInteger remainder = number % scale;
+            BigInteger fraction = remainder * 1000 / scale;
+            string fractionString = ((int)fraction).ToString("D3", CultureInfo.CurrentUICulture).TrimEnd('0');
+
+            if (fractionString.Length > 0)
             {
-                result += CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator + firstDigit.ToString(CultureInfo.CurrentUICulture);
+                result += CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator + fractionString;
             }
         }
 


### PR DESCRIPTION
## Summary
- Display fractional part when formatting large tap counts
- Document updated example for tap counter formatting

## Testing
- `dotnet build` *(fails: The target platform identifier android was not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68941673df808332b0173f193bd5ae10