### PR TITLE
Add JWT authentication for SignalR

### DIFF
--- a/ClientCredentials.cs
+++ b/ClientCredentials.cs
@@ -1,0 +1,10 @@
+namespace LizardButton;
+
+internal static class ClientCredentials
+{
+    /// <summary>
+    /// Client secret used to request JWTs from the server.
+    /// Replace the placeholder value with your actual secret.
+    /// </summary>
+    public const string ClientSecret = "REPLACE_WITH_CLIENT_SECRET";
+}

--- a/README.md
+++ b/README.md
@@ -21,12 +21,13 @@ LizardButton is a minimal [.NET MAUI](https://learn.microsoft.com/dotnet/maui/wh
    ```bash
    dotnet workload restore
    ```
-2. Build the project:
+2. Set the client secret used for JWT authentication in `ClientCredentials.cs`.
+3. Build the project:
    ```bash
    dotnet build
    ```
    If required workloads are missing, the build output will show the command needed to install them.
-3. Run the app for a specific platform (example for Android):
+4. Run the app for a specific platform (example for Android):
    ```bash
    dotnet build -t:Run -f net8.0-android
    ```


### PR DESCRIPTION
## Summary
- Retrieve JWTs with a client secret and use them as the SignalR access token
- Add placeholder client secret configuration
- Document new JWT setup step in README

## Testing
- `dotnet build` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689600ddc7dc833295bdffd79a2dc04c