### PR TITLE
Enhance central button pressed effect

### DIFF
--- a/MainPage.xaml
+++ b/MainPage.xaml
@@ -39,33 +39,39 @@
                 <RoundRectangle CornerRadius="70" />
             </Border.StrokeShape>
             <Border.Shadow>
-                <Shadow Brush="{AppThemeBinding Light={StaticResource BlackBrush}, Dark={StaticResource WhiteBrush}}"
+                <Shadow x:Name="ButtonShadow"
+                        Brush="{AppThemeBinding Light={StaticResource BlackBrush}, Dark={StaticResource WhiteBrush}}"
                         Opacity="0.5"
                         Radius="15"
                         Offset="0,10" />
             </Border.Shadow>
-            <ImageButton Padding="20"
-                         Aspect="Fill"
-                         BackgroundColor="Transparent"
-                         Clicked="OnCentralButtonClicked"
-                         Source="lizard.png">
-                <VisualStateManager.VisualStateGroups>
-                    <VisualStateGroupList>
-                        <VisualStateGroup x:Name="CommonStates">
-                            <VisualState x:Name="Normal">
-                                <VisualState.Setters>
-                                    <Setter Property="Scale" Value="1" />
-                                </VisualState.Setters>
-                            </VisualState>
-                            <VisualState x:Name="Pressed">
-                                <VisualState.Setters>
-                                    <Setter Property="Scale" Value="0.9" />
-                                </VisualState.Setters>
-                            </VisualState>
-                        </VisualStateGroup>
-                    </VisualStateGroupList>
-                </VisualStateManager.VisualStateGroups>
-            </ImageButton>
+            <VisualStateManager.VisualStateGroups>
+                <VisualStateGroupList>
+                    <VisualStateGroup x:Name="CommonStates">
+                        <VisualState x:Name="Normal">
+                            <VisualState.Setters>
+                                <Setter Property="Scale" Value="1" />
+                                <Setter Property="TranslationY" Value="0" />
+                                <Setter TargetName="ButtonShadow" Property="Offset" Value="0,10" />
+                            </VisualState.Setters>
+                        </VisualState>
+                        <VisualState x:Name="Pressed">
+                            <VisualState.Setters>
+                                <Setter Property="Scale" Value="0.95" />
+                                <Setter Property="TranslationY" Value="5" />
+                                <Setter TargetName="ButtonShadow" Property="Offset" Value="0,5" />
+                            </VisualState.Setters>
+                        </VisualState>
+                    </VisualStateGroup>
+                </VisualStateGroupList>
+            </VisualStateManager.VisualStateGroups>
+            <Border.GestureRecognizers>
+                <TapGestureRecognizer Tapped="OnCentralButtonClicked" />
+            </Border.GestureRecognizers>
+            <Image Padding="20"
+                   Aspect="Fill"
+                   BackgroundColor="Transparent"
+                   Source="lizard.png" />
         </Border>
         <admob:BannerAd Grid.Row="3"
                         AdSize="Banner"


### PR DESCRIPTION
## Summary
- Move visual state management from ImageButton to parent Border and add a pressed state with scale, translation, and shadow offset changes
- Replace ImageButton with Image and hook a TapGestureRecognizer on the Border so tapping anywhere triggers the button action

## Testing
- `dotnet build` *(fails: NETSDK1147 workload wasi-experimental missing)*
- `dotnet workload restore`

------
https://chatgpt.com/codex/tasks/task_e_689686540f3c8332b951fc65b81ac42e